### PR TITLE
Added exception for invalid user, to use in glue.php

### DIFF
--- a/src/tdt/exceptions/exceptions.ini
+++ b/src/tdt/exceptions/exceptions.ini
@@ -34,6 +34,11 @@ documentation="This formatter is not able to print graph information"
 parameters=""
 message="This formatter is not able to print graph information"
 short="Formatter mismatch"
+[454]
+documentation="User for route is invalid"
+parameters=""
+message="There's been given an invalid user for this route: $1"
+short="Invalid user"
 ; 5xx errors
 [500]
 documentation="Exception for when a severe server error has occured."


### PR DESCRIPTION
In glue.php, a wrong error was given when there was an invalid user in a route. I solved this in the oSoc13 fork of tdt-start, but it needs a new exception, because there was none for this problem yet.
